### PR TITLE
Add unit declarator to role declarations

### DIFF
--- a/lib/Class/Utils.pm6
+++ b/lib/Class/Utils.pm6
@@ -2,7 +2,7 @@
 # extend them and access properties the same way.  This just lets you apply
 # the role Has to have your objects blessed, rather than having to do it in
 # each class manually.
-role Has;
+unit role Has;
 
 method new (*@elems, *%attrs) {
   my $cand = self.Array::new(@elems);


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class`, `role` or `grammar` declarations (unless it uses a
block).  Code still using the old blockless semicolon form will throw a
warning. This commit stops the warning from appearing in the new Rakudo.